### PR TITLE
fix typo for border-radius in about-us section

### DIFF
--- a/src/css/about_us.css
+++ b/src/css/about_us.css
@@ -67,7 +67,7 @@
   .about-us--image {
     width: 100%;
     height: 243px;
-    background-repeat: 30px;
+    border-radius: 30px;
   }
 }
 


### PR DESCRIPTION
Прописав скорочено в коді при розробці br (border-radius), а автоматично підставилось background-repeat